### PR TITLE
Fix alignment on different size windows

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -1,7 +1,7 @@
 @import "syntax-variables";
 
 atom-text-editor {
-	background-color: rgba(55, 55, 55, 0.5);
+	background-color: rgba(55, 55, 55, 1.0);
   color: @syntax-text-color;
 
   .wrap-guide {
@@ -302,9 +302,12 @@ atom-text-editor[mini] .scroll-view {
 }
 
 .editor {
-  width: 31.5%;
-  height: 35.5%;
-  margin: 7% 0 0 12.2%;
+  width: 32.1%;
+  height: 36.7%;
+  top: 10.7%;
+  right: 0;
+  bottom: 0;
+  left: 12.2%;
   transform: rotate(-0.65deg);
 }
 


### PR DESCRIPTION
This fixes the alignment of the editor as the window scales.

![image](https://user-images.githubusercontent.com/519171/27612324-fc40add6-5b63-11e7-8682-070ba57768eb.png)
